### PR TITLE
added oexserverd path for Ubuntu Kinetic (22.10)

### DIFF
--- a/oesenc-export.py
+++ b/oesenc-export.py
@@ -106,7 +106,7 @@ def locateService():
             return shutil.which("oeserverd.exe", path=r'C:\Program Files (x86)\OpenCPN\plugins\oesenc_pi')
 
     else:
-        oexserverdDirs = [os.path.expandvars('$HOME/.var/app/org.opencpn.OpenCPN/bin'), '/usr/local/bin/' '/usr/bin/']
+        oexserverdDirs = [os.path.expandvars('$HOME/.local/bin'), os.path.expandvars('$HOME/.var/app/org.opencpn.OpenCPN/bin'), '/usr/local/bin/' '/usr/bin/']
 
         for dir in oexserverdDirs:
             exe = shutil.which('oexserverd', path=dir)


### PR DESCRIPTION
Installation path seems to have changed.
I used a freshly installed kubuntu 22.10, opencpn installed from the latest available ppa:
`deb https://ppa.launchpadcontent.net/opencpn/opencpn/ubuntu/ jammy main`