### PR TITLE
Look for oexserverd in avnav ochart plugin dirs

### DIFF
--- a/oesenc-export.py
+++ b/oesenc-export.py
@@ -109,7 +109,9 @@ def locateService():
         oexserverdDirs = [os.path.expandvars('$HOME/.var/app/org.opencpn.OpenCPN/bin'),
                           os.path.expandvars('$HOME/.local/bin'),
                           '/usr/local/bin',
-                          '/usr/bin']
+                          '/usr/bin',
+                          '/usr/lib/avnav/plugins/ocharts/bin/',
+                          '/usr/lib/avnav/plugins/ochartsng']
 
         for dir in oexserverdDirs:
             exe = shutil.which('oexserverd', path=dir)


### PR DESCRIPTION
There are two such plugins for avnav:

- ochartsplugin will place oexserverd in /usr/lib/avnav/plugins/ocharts/bin
- ochartsng will install oexserverd in /usr/lib/avnav/plugins/ochartsng.